### PR TITLE
Added support for CAT24C02/04/08/16 devices

### DIFF
--- a/I2CEEPROM.cpp
+++ b/I2CEEPROM.cpp
@@ -11,26 +11,31 @@
 #include "I2CEEPROM.h"
 #include <Wire.h>
 
-I2CEEPROM::I2CEEPROM(int i2c_device_address, int addressing_mode)
+I2CEEPROM::I2CEEPROM(int i2c_device_address, enum address_mode addressing_mode, boolean initialize_wire)
 {
   _i2c_device_address = i2c_device_address;
   _addressing_mode = addressing_mode;
 
+  // Set the address mask (as defined in enum) to properly set I2C address when writing/reading
   if(addressing_mode == ADDRESS_MODE_16BIT) {
     _i2c_address_mask = 0xFF;
   } else {
     _i2c_address_mask = (0xFF << addressing_mode);
   }
+  
+  // Compatibility -- defaults to true to automatically initialize the Wire library, but it may be unwanted by some users.
+  if(initialize_wire) Wire.begin();
 }
 
 void I2CEEPROM::write(unsigned int address, byte data) const
 {
+  // Generate the proper I2C address based on device mask and memory address
   uint8_t dev_address = generate_I2C_address(address);
 
   Wire.beginTransmission(dev_address);
-  // Send an extra address byte in 16 bit addressing:
-  if(_addressing_mode == ADDRESS_MODE_16BIT) Wire.write((int)(address >> 8));   // First part of the address (MSB)
-  Wire.write((int)(address & 0xFF)); // Second part of the address (LSB)
+  // In classic device mode, send the 8 MSB of the memory address.  This is already part of the device addr in CAT24CXX
+  if(_addressing_mode == ADDRESS_MODE_16BIT) Wire.write((byte)(address >> 8));   // First part of the address (MSB)
+  Wire.write((byte)(address & 0xFF)); // Second part of the address (LSB)
   Wire.write(data);                  // Write byte
   Wire.endTransmission();
 
@@ -40,13 +45,14 @@ void I2CEEPROM::write(unsigned int address, byte data) const
 
 byte I2CEEPROM::read(unsigned int address) const
 {
+  // Generate the proper I2C address based on device mask and memory address
   uint8_t dev_address = generate_I2C_address(address);
   byte read_data = 0xFF;
 
   Wire.beginTransmission(dev_address);
-  // Send an extra address byte in 16 bit addressing:
-  if(_addressing_mode == ADDRESS_MODE_16BIT) Wire.write((int)(address >> 8));   // MSB
-  Wire.write((int)(address & 0xFF)); // LSB
+  // In classic device mode, send the 8 MSB of the memory address.  This is already part of the device addr in CAT24CXX
+  if(_addressing_mode == ADDRESS_MODE_16BIT) Wire.write((byte)(address >> 8));   // MSB
+  Wire.write((byte)(address & 0xFF)); // LSB
   Wire.endTransmission();
 
   // Request 1 byte from device
@@ -65,7 +71,7 @@ uint8_t I2CEEPROM::generate_I2C_address(uint16_t address) const
   uint8_t dev_address = _i2c_device_address;
 
   if(_addressing_mode != ADDRESS_MODE_16BIT) {
-    // Set the N LSB of the address to the N LSB of the high-byte of the address
+    // Set the N MSB of the address to the N LSB of the high-byte of the address
     dev_address = (_i2c_device_address & _i2c_address_mask) | ((address >> 8) & (~_i2c_address_mask));
   }
 

--- a/I2CEEPROM.cpp
+++ b/I2CEEPROM.cpp
@@ -11,16 +11,25 @@
 #include "I2CEEPROM.h"
 #include <Wire.h>
 
-I2CEEPROM::I2CEEPROM(int i2c_device_address)
+I2CEEPROM::I2CEEPROM(int i2c_device_address, int addressing_mode)
 {
   _i2c_device_address = i2c_device_address;
-  Wire.begin();
+  _addressing_mode = addressing_mode;
+
+  if(addressing_mode == ADDRESS_MODE_16BIT) {
+    _i2c_address_mask = 0xFF;
+  } else {
+    _i2c_address_mask = (0xFF << addressing_mode);
+  }
 }
 
 void I2CEEPROM::write(unsigned int address, byte data) const
 {
-  Wire.beginTransmission(_i2c_device_address);
-  Wire.write((int)(address >> 8));   // MSB
+  uint8_t dev_address = generate_I2C_address(address);
+
+  Wire.beginTransmission(dev_address);
+  // Send an extra address byte in 16 bit addressing:
+  if(_addressing_mode == ADDRESS_MODE_16BIT) Wire.write((int)(address >> 8));   // MSB
   Wire.write((int)(address & 0xFF)); // LSB
   Wire.write(data);                  // Write byte
   Wire.endTransmission();
@@ -31,19 +40,33 @@ void I2CEEPROM::write(unsigned int address, byte data) const
 
 byte I2CEEPROM::read(unsigned int address) const
 {
+  uint8_t dev_address = generate_I2C_address(address);
   byte read_data = 0xFF;
 
-  Wire.beginTransmission(_i2c_device_address);
-  Wire.write((int)(address >> 8));   // MSB
+  Wire.beginTransmission(dev_address);
+  // Send an extra address byte in 16 bit addressing:
+  if(_addressing_mode == ADDRESS_MODE_16BIT) Wire.write((int)(address >> 8));   // MSB
   Wire.write((int)(address & 0xFF)); // LSB
   Wire.endTransmission();
 
   // Request 1 byte from device
-  Wire.requestFrom(_i2c_device_address, 1);
+  Wire.requestFrom(dev_address, 1);
 
   if (Wire.available()) {
     read_data = Wire.read();
   }
 
   return read_data;
+}
+
+uint8_t I2CEEPROM::generate_I2C_address(uint16_t address) const 
+{
+  uint8_t dev_address = _i2c_device_address;
+
+  if(_addressing_mode != ADDRESS_MODE_16BIT) {
+    // Set the N LSB of the address to the N LSB of the high-byte of the address
+    dev_address = (_i2c_device_address & _i2c_address_mask) | ((address >> 8) & (~_i2c_address_mask));
+  }
+
+  return dev_address;
 }

--- a/I2CEEPROM.h
+++ b/I2CEEPROM.h
@@ -21,23 +21,35 @@
 #include "WProgram.h"
 #endif
 
-// Enum to set the number of bits used in I2C address for the memory address.
-enum {
+// Enum to set the number of bits used in I2C address for the memory address for CAT24CXX devices.
+// The "Classic" device sends the address and then 16-bits for the address.
+// The CAT24CXX devices include the 'n' MSB of the MEMORY address as the 'n' LSB of the I2C address.
+//    Where n is 3 for the 16 kb, 2 for the 8 kb, 1 for the 4 kb, and 0 for the 2kb
+enum address_mode {
     ADDRESS_MODE_16BIT,
     ADDRESS_MODE_8BIT = 0,
-    ADDRESS_MODE_9BIT = 1,
+    ADDRESS_MODE_9BIT = 1, 
     ADDRESS_MODE_10BIT = 2,
     ADDRESS_MODE_11BIT = 3
 };
+
+// Map device names to Addressing mode to make it easier to use
+#define EEPROM_DEVICE_CLASSIC  ADDRESS_MODE_16BIT
+#define EEPROM_DEVICE_CAT24C02 ADDRESS_MODE_8BIT
+#define EEPROM_DEVICE_CAT24C04 ADDRESS_MODE_9BIT
+#define EEPROM_DEVICE_CAT24C08 ADDRESS_MODE_10BIT
+#define EEPROM_DEVICE_CAT24C16 ADDRESS_MODE_11BIT
 
 class I2CEEPROM
 {
   public:
     /*!
      * \brief I2CEEPROM Initialize I2C EEPROM instance
-     * \param device_address (int) I2C address of the EEPROM device
+     * \param device_address (int) I2C address  of the EEPROM device
+     * \param addressing_mode (enum) Selects the device in use (defaults to "Classic", non CAT24CXX)
+     * \param initialize_wire (boolean) Initializes the Wire library (defaults to true)
      */
-    I2CEEPROM(int i2c_device_address = 0x50, int addressing_mode = ADDRESS_MODE_16BIT);
+    I2CEEPROM(int i2c_device_address = 0x50, enum address_mode addressing_mode = EEPROM_DEVICE_CLASSIC, boolean initialize_wire = true);
 
     /*!
      * \brief write Write one byte \p data in EEPROM device at EEPROM internal address \p address

--- a/I2CEEPROM.h
+++ b/I2CEEPROM.h
@@ -21,6 +21,15 @@
 #include "WProgram.h"
 #endif
 
+// Enum to set the number of bits used in I2C address for the memory address.
+enum {
+    ADDRESS_MODE_16BIT,
+    ADDRESS_MODE_8BIT = 0,
+    ADDRESS_MODE_9BIT = 1,
+    ADDRESS_MODE_10BIT = 2,
+    ADDRESS_MODE_11BIT = 3
+};
+
 class I2CEEPROM
 {
   public:
@@ -28,7 +37,7 @@ class I2CEEPROM
      * \brief I2CEEPROM Initialize I2C EEPROM instance
      * \param device_address (int) I2C address of the EEPROM device
      */
-    I2CEEPROM(int i2c_device_address);
+    I2CEEPROM(int i2c_device_address = 0x50, int addressing_mode = ADDRESS_MODE_16BIT);
 
     /*!
      * \brief write Write one byte \p data in EEPROM device at EEPROM internal address \p address
@@ -45,7 +54,17 @@ class I2CEEPROM
     byte read(unsigned int address) const;
 
   private:
+    /*!
+     * \brief read Combine I2C address with high byte of address for 512-2048 byte devices, return regular address for 16-bit addressed devices.
+     * \param address (uint16_T) EEPROM internal address
+     * \return (uint8_t) Read Byte at EEPROM internal address \p address (returns 0xFF if an error occurred)
+     */
+    uint8_t generate_I2C_address(uint16_t address) const;
+
+  private:
     int _i2c_device_address;
+    int _addressing_mode;
+    int _i2c_address_mask;
 };
 
 #endif //I2CEEPROM_h


### PR DESCRIPTION
I finally got around to back-porting in the compatibility of the original library into the fork.

I don't have one of the 16-bit addressing I2C devices to test with though, so I hope that I didn't break anything.